### PR TITLE
fix: wrong divider variable

### DIFF
--- a/Assets/Scripts/Loot.cs
+++ b/Assets/Scripts/Loot.cs
@@ -115,7 +115,7 @@ public class Loot : MonoBehaviour
 
 			if (bounces < settings.numberOfBounces)
 			{
-				Initialize(new Vector2(groundVelocity.x / settings.XReducer, groundVelocity.y / settings.XReducer));
+				Initialize(new Vector2(groundVelocity.x / settings.XReducer, groundVelocity.y / settings.YReducer));
 			}
 			else {
 


### PR DESCRIPTION
I believe this was a simple typing issue. If this was intended, feel free to just close this pull request. :)